### PR TITLE
fix: missing handling on query error checking

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -148,7 +148,7 @@ export abstract class Provider {
 
     getCodeError(req: Hapi.Request): CodeError | null {
         const err = req.query['error'];
-        if (err === null) {
+        if (err === null || err === undefined) {
             return null;
         }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -148,7 +148,7 @@ export abstract class Provider {
 
     getCodeError(req: Hapi.Request): CodeError | null {
         const err = req.query['error'];
-        if (err === null || err === undefined) {
+        if (err == null) {
             return null;
         }
 


### PR DESCRIPTION
The value of the query being returned can differ from what plugins are installed on Hapi. A few overrides it returns null, but by default, the returned value is undefined.

This fixes an issue with correct auth flows being thrown as errors, due to this check throwing a false positive.